### PR TITLE
docs(adr): add ADR template and initial repo structure ADR

### DIFF
--- a/docs/adr/adr-001-repo-structure.md
+++ b/docs/adr/adr-001-repo-structure.md
@@ -1,0 +1,28 @@
+# ADR-001: Initial Repository Structure
+
+- Date: 2025-08-25
+- Status: Accepted
+
+## Context
+
+We need a clear, maintainable structure for the VS Code Accessibility Assistant extension, supporting documentation, tests, and future features.
+
+## Decision
+
+Adopt the planned repo structure:
+
+- `src/` for extension code
+- `test/` for tests
+- `docs/` for documentation
+- `.github/` for templates and workflows
+- Root files for config and metadata
+
+## Consequences
+
+- Easier onboarding and navigation
+- Supports best practices for open source projects
+
+## Alternatives Considered
+
+- Keeping Yeoman-generated subfolder (rejected for clarity)
+- Flat structure without subfolders (rejected for scalability)


### PR DESCRIPTION
This PR adds:

- ADR-000-template.md: The template for future architecture decision records.
- adr-001-repo-structure.md: The first ADR documenting the initial repository structure.
These changes support the documentation approach outlined in Step 4 of the project plan.

Checklist:

 - [x] ADR template added
 - [x] Initial repo structure ADR added
 - [x] Conventional commit used
 - [x] Documentation conventions followed

## Summary by Sourcery

Add a template for architecture decision records and document the initial repository structure according to the project plan

Documentation:
- Add ADR template for future architectural decisions
- Add ADR documenting the initial repository structure