### PR TITLE
feat(quick-fixes): add aria-describedby, heading structure, and label checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,16 @@
 ## Features (MVP)
 
 - Hover/help docs for common components (buttons, dialogs, menus, form fields)
-- Quick fixes for common mistakes (e.g., missing aria-label on icons, incorrect role)
+- Quick fixes for common accessibility mistakes:
+  - Missing aria-label on icons/images
+  - Missing aria-describedby on form elements
+  - Incorrect heading structure (skipped heading levels)
+  - Inputs missing associated <label>
 - Auditor: scans active editor text and highlights likely accessibility issues
+
+## Roadmap
+
+See [ROADMAP.md](./ROADMAP.md) for planned features, improvements, and future ideas for v0.2.0 and beyond.
 
 ## Getting Started
 
@@ -32,7 +40,12 @@ Use the Command Palette (`Ctrl+Shift+P` or `Cmd+Shift+P`) and search for:
 - **Insert ARIA Disclosure Snippet**
   - Accessible disclosure (accordion) pattern with ARIA attributes
 - **Quick Fixes**
-  - Detects and suggests fixes for missing aria-labels, incorrect roles, and other common accessibility mistakes
+  - Detects and suggests fixes for:
+    - Missing aria-labels on role="img" elements
+    - Missing aria-describedby on form elements
+    - Incorrect heading structure (skipped heading levels)
+    - Inputs missing associated <label>
+  - Results are shown in the Accessibility Quick Fixes output channel
 - **Auditor**
   - Scans the active editor for accessibility issues and highlights likely problems
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,39 @@
+# Roadmap
+
+## v0.2.0 (Planned)
+
+### Features
+
+- Add more accessibility quick fixes (aria-describedby, heading structure, form labels)
+- Expand auditor rules (color contrast, tab order, landmark roles, heading hierarchy)
+- Generate downloadable/copyable accessibility reports
+- Make auditor rules configurable via settings
+- Add more ARIA/POUR pattern snippets (tabs, tooltips, alerts, live regions)
+- Provide inline accessibility suggestions and hover tips
+- Support multi-file and workspace-wide audits
+- Integrate with axe-core or other accessibility engines
+- Add documentation links to hover/help popups
+- Allow user-defined accessibility patterns/snippets
+
+### Process
+
+- Track each feature as a GitHub issue
+- Reference issues in PRs to auto-close
+- Update documentation and tests for new features
+
+---
+
+## Future Ideas
+
+- Accessibility linting on save
+- Automated accessibility regression testing
+- Community-contributed snippet library
+- Localization/internationalization support
+
+---
+
+## How to Contribute
+
+- See CONTRIBUTING.md for workflow and conventions
+- Open issues for feature requests or bugs
+- Submit PRs referencing relevant issues

--- a/src/commands/quickFixes.ts
+++ b/src/commands/quickFixes.ts
@@ -9,7 +9,7 @@ export function registerQuickAccessibilityFixes(context: vscode.ExtensionContext
     }
     const text = editor.document.getText();
     let fixes = [];
-    // Example: Find <i> or <span> with role="img" but missing aria-label
+    // Find <i> or <span> with role="img" but missing aria-label
     const imgRoleRegex = /<(i|span)[^>]*role=["']img["'][^>]*>/gi;
     let match;
     while ((match = imgRoleRegex.exec(text)) !== null) {
@@ -20,12 +20,51 @@ export function registerQuickAccessibilityFixes(context: vscode.ExtensionContext
         });
       }
     }
+    // Find elements with aria-describedby missing
+    const describedbyRegex = /<(input|textarea|select)[^>]*>/gi;
+    while ((match = describedbyRegex.exec(text)) !== null) {
+      if (!/aria-describedby=/.test(match[0])) {
+        fixes.push({
+          index: match.index,
+          message: `<${match[1]}> is missing aria-describedby.`,
+        });
+      }
+    }
+    // Find headings with incorrect structure (e.g., h1 followed by h3)
+    const headingRegex = /<h([1-6])[^>]*>/gi;
+    let lastLevel = 0;
+    while ((match = headingRegex.exec(text)) !== null) {
+      const level = parseInt(match[1], 10);
+      if (lastLevel && level > lastLevel + 1) {
+        fixes.push({
+          index: match.index,
+          message: `Heading structure skips a level: <h${lastLevel}> followed by <h${level}>.`,
+        });
+      }
+      lastLevel = level;
+    }
+    // Find <input> missing associated <label>
+    const inputRegex = /<input[^>]*id=["']([^"']+)["'][^>]*>/gi;
+    while ((match = inputRegex.exec(text)) !== null) {
+      const labelRegex = new RegExp(`<label[^>]*for=["']${match[1]}["'][^>]*>`, 'i');
+      if (!labelRegex.test(text)) {
+        fixes.push({
+          index: match.index,
+          message: `Input with id="${match[1]}" is missing associated <label>.`,
+        });
+      }
+    }
     if (fixes.length === 0) {
       vscode.window.showInformationMessage('No quick accessibility fixes found.');
     } else {
       vscode.window.showInformationMessage(
-        `${fixes.length} quick accessibility fix(es) found. Check your code for missing aria-labels on role="img" elements.`
+        `${fixes.length} quick accessibility fix(es) found. See output for details.`
       );
+      const output = vscode.window.createOutputChannel('Accessibility Quick Fixes');
+      output.clear();
+      output.appendLine('Accessibility Quick Fixes Found:');
+      fixes.forEach((fix) => output.appendLine(`Index ${fix.index}: ${fix.message}`));
+      output.show();
     }
   });
   context.subscriptions.push(disposable);


### PR DESCRIPTION
Description:

- Expands the quick fixes command to detect:
   - Missing aria-describedby on form elements
   - Incorrect heading structure (skipped heading levels)
   - Inputs missing associated <label>
- Updates documentation to reflect new quick fixes and output channel usage
- Closes #17 
